### PR TITLE
Ensures es6 Imports and Exports Don't Cause Errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,13 @@
 module.exports = {
-	"extends": "@webdevstudios/eslint-config-js-coding-standards"
+	"extends": "@webdevstudios/eslint-config-js-coding-standards",
+	"env": {
+		"browser": true,
+		"jquery": true,
+		"es6": true
+	},
+	"parserOptions": {
+	   	"ecmaVersion": 6,
+	  	"sourceType": "module",
+	  	"allowImportExportEverywhere": true
+	}
 }


### PR DESCRIPTION
Before this change, let's say you have some simple code like the following atop a JS file:
```
import Cool from './Cool';
import Wow from './Wow';
```
**Even with `es6: true` enabled in our coding standards' `.eslintrc.js` file, these trigger a linting error** as follows:
```
Parsing error: 'import' and 'export' may appear only with 'sourceType: module'
```
This is an error that is [often fixed](https://github.com/AtomLinter/linter-eslint/issues/462) just by adding `sourceType: module` to the `.eslintrc.js`'s `parserOptions` option, but I've found that it required all of the changes seen in this file diff to make it work.