### PR TITLE
Feature/prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,16 @@ module.exports = {
 		 * @report   Error
 		 */
 		'lines-around-comment': [ 'error', {
+			beforeBlockComment: true,
+			afterBlockComment: false,
 			beforeLineComment: true,
+			afterLineComment: false,
+			allowBlockStart: true,
+			allowBlockEnd: true,
+			allowObjectStart: true,
+			allowObjectEnd: true,
+			allowArrayStart: true,
+			allowArrayEnd: true
 		} ],
 
 		/**

--- a/index.js
+++ b/index.js
@@ -134,24 +134,6 @@ module.exports = {
 		'func-call-spacing': 'off',
 
 		/**
-		 * Enforces spacing between keys and values in object literal properties.
-		 *
-		 * @standard WP
-		 * @see      https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#spacing
-		 *
-		 * @author   Aubrey Portwood
-		 * @since    1.0
-		 *
-		 * @since    7/26/2019 Overrides WP.
-		 *
-		 * @report   Error
-		 */
-		'key-spacing': [ 'error', {
-			beforeColon: false,
-			afterColon: true,
-		} ],
-
-		/**
 		 * Enforces empty lines around comments.
 		 *
 		 * @standard WP

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 	 *
 	 * @since 1.0.0
 	 */
-	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended', 'prettier', 'prettier/react' ],
 
 	plugins: [
 		'@webdevstudios/js-coding-standards',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@webdevstudios/eslint-plugin-js-coding-standards": "~1.0.0",
     "@wordpress/eslint-plugin": "~2.3.0",
-    "eslint": "~6.1.0"
+    "eslint": "~6.1.0",
+    "eslint-config-prettier": "^6.10.1"
   },
   "devDependencies": {},
   "main": "index.js",


### PR DESCRIPTION
Based on https://github.com/WebDevStudios/js-coding-standards/issues/2, **the goal is to let Prettier deal with formatting.**

While ESLint can also be a formatter, the scope is limited to JavaScript. Prettier on the other hand, can format just about everything, except PHP.

Also, in my opinion, WDS should revaluate how we're doing JS, Sass, and CSS coding standards and use Gutenberg and their sharable configs as the baseline.

## Table of contents
- [Description](#description)
	- [@wordpress/scripts based projects](#wordpressscripts-based-projects)
	- [Non-@wordpress/scripts Projects](#non-wordpressscripts-projects)
- [Configure Code Editor](#configure-code-editor)
	- [Inform the Code Editor](#inform-the-code-editor)
- [Verify ESLint and Prettier Rules](#verify-eslint-and-prettier-rules)
- [Disable Prettier](#disable-prettier)

## Description

### @wordpress/scripts based projects

As of [two weeks ago](https://github.com/WordPress/gutenberg/pull/20026), both Gutenberg and [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) support Prettier. There's also a [sharable config](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/config/.prettierrc.js).

If WDS has a project using `@wordpress/scripts`, we can create a `.prettierrc.js` file in the project root with the following:

```js
module.exports = require("@wordpress/prettier-config");
```

### Non-@wordpress/scripts Projects

Based on [Prettier's documentation](https://prettier.io/docs/en/integrating-with-linters.html#eslint) as well as the `eslint-config-prettier` [docs](https://github.com/prettier/eslint-config-prettier#installation), this PR adds support for Prettier by:

1. Add `eslint-config-prettier` dependency
1. Extend Prettier configs
1. Remove any conflicting ESLint _formatting_ rules

Learn more about configuration: https://github.com/prettier/eslint-config-prettier#example-configuration

## Configure Code Editor

In your favorite code editor, make sure you have an ESLint, [Prettier](https://prettier.io/docs/en/editors.html), and EditorConfig extensions installed and turned on. For example, here are the settings for VS Code:

```
  "editor.formatOnSave": true,  // Enables all formatting. Prettier depends on this.
  "editor.codeActionsOnSave": {
    "source.fixAll": true,  // A new VS Code setting to enable fixing.
    "source.fixAll.eslint": true. // Give ESLint permission to auto fix code quality issues.
  },
  "eslint.format.enable": false,  // A stop-gap, to prevent ESLint from trying to format on save.
  "[javascriptreact]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode". // Set a default formatter for JavaScript/React to Prettier.
  },
```

### Inform the Code Editor

Every WDS project should have an `.editorconfig`. This is the most basic way to ensure all our code editors are on the same page. Prettier looks for `.editorconfig` as a possible config file.

Here are the config files Prettier looks for, in order:

1. `.prettierrc` or `.prettierrc.js`
2. `.editorconfig`
3. Code editor defaults
4. Bundled defaults

This is the recommended `,editorconfig` configuration [directly from WordPress](https://github.com/WordPress/gutenberg/blob/master/.editorconfig).

```yml
# This file is for unifying the coding style for different editors and IDEs
# editorconfig.org

# WordPress Coding Standards
# https://make.wordpress.org/core/handbook/coding-standards/

root = true

[*]
charset = utf-8
end_of_line = lf
insert_final_newline = true
trim_trailing_whitespace = true
indent_style = tab
indent_size = 4

[*.yml]
indent_style = space
indent_size = 2

[*.md]
trim_trailing_whitespace = false
```

## Verify ESLint and Prettier Rules

The `eslint-config-prettier` package comes with [CLI utility](https://github.com/prettier/eslint-config-prettier#cli-helper-tool) to verify that both ESLint and Prettier are playing together nicely.,

Run `npx eslint --print-config path/to/main.js | npx eslint-config-prettier-check`

If everything is OK, you should see: `No rules that are unnecessary or conflict with Prettier were found.`

## Disable Prettier

Don't want to use Prettier on a project? Don't want to mess with your code editor settings to disable Prettier? [Prettier can ignore](https://prettier.io/docs/en/ignore.html) files and directories at the project level. **Add a `.prettierignore` file to the root of your project.** Note: `prettierignore follows the`.gitignore` syntax. [Learn more](https://prettier.io/docs/en/ignore.html)

```
src/
foo/filename.js
```
