### PR TITLE
Don't Allow Multispaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,5 +275,18 @@ module.exports = {
 		 * @report Off
 		 */
 		'padded-blocks': 'off',
+
+		/**
+		 * Do not allow multiple spaces.
+		 *
+		 * @standard WDS
+		 *
+		 * @author Aubrey Portwood <aubrey@webdevstudios.com
+		 * @since  NEXT
+		 *
+		 * @see      https://eslint.org/docs/rules/no-multi-spaces
+		 * @report   Error
+		 */
+		'no-multi-space': [ 'error' ],
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,9 +129,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-jsx": {
       "version": "5.0.2",

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ __________
 
 ## NEXT
 
+- Don't allow multi spaces <sup>[eslint](https://eslint.org/docs/rules/no-multi-spaces)</sup>
 - Bump acorn from 7.1.0 to 7.1.1 <sup>[PR](https://github.com/WebDevStudios/eslint-config-js-coding-standards/pull/14)</sup>
 
 ## 1.0.1

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,10 @@ __________
 
 # Changelog
 
+## NEXT
+
+- Bump acorn from 7.1.0 to 7.1.1 <sup>[PR](https://github.com/WebDevStudios/eslint-config-js-coding-standards/pull/14)</sup>
+
 ## 1.0.1
 
 - Allow arrow functions <sup>[PR:#12](https://github.com/WebDevStudios/eslint-config-js-coding-standards/pull/12)</sup>


### PR DESCRIPTION
Having multiple spaces in our code is un-clean and can help us catch un-necessary spaces.