### PR TITLE
Don't allow multispaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,5 +275,18 @@ module.exports = {
 		 * @report Off
 		 */
 		'padded-blocks': 'off',
+
+		/**
+		 * Do not allow multiple spaces.
+		 *
+		 * @standard WDS
+		 *
+		 * @author Aubrey Portwood <aubrey@webdevstudios.com
+		 * @since  NEXT
+		 *
+		 * @see      https://eslint.org/docs/rules/no-multi-spaces
+		 * @report   Error
+		 */
+		'no-multi-space': [ 'error' ],
 	},
 };

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ __________
 
 ## NEXT
 
+- Don't allow multi spaces <sup>[eslint](https://eslint.org/docs/rules/no-multi-spaces)</sup>
 - Bump acorn from 7.1.0 to 7.1.1 <sup>[PR](https://github.com/WebDevStudios/eslint-config-js-coding-standards/pull/14)</sup>
 
 ## 1.0.1


### PR DESCRIPTION
This allows our code to be cleaner and help us catch double spaces, etc.