### PR TITLE
Rename no-multi-space to no-multi-spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,6 +287,6 @@ module.exports = {
 		 * @see      https://eslint.org/docs/rules/no-multi-spaces
 		 * @report   Error
 		 */
-		'no-multi-space': [ 'error' ],
+		'no-multi-spaces': [ 'error' ],
 	},
 };

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,10 @@ __________
 
 # Changelog
 
+## Unrealeased
+
+- Correct the `no-multi-space` which is incorrect to `no-multi-spaces` which is the correct rule
+
 ## 1.0.2
 
 - Don't allow multi spaces <sup>[eslint](https://eslint.org/docs/rules/no-multi-spaces)</sup>


### PR DESCRIPTION
If you look at https://eslint.org/docs/rules/no-multi-spaces it has an `s` at the end.